### PR TITLE
[WIP] Add ProjectNavigator OutlineTableViewCell to display file exten…

### DIFF
--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineView.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineView.swift
@@ -31,6 +31,9 @@ struct OutlineView: NSViewControllerRepresentable {
     func updateNSViewController(_ nsViewController: OutlineViewController, context: Context) {
         nsViewController.iconColor = prefs.preferences.general.fileIconStyle
         nsViewController.rowHeight = rowHeight
+        nsViewController.fileExtensionsVisibility = prefs.preferences.general.fileExtensionsVisibility
+        nsViewController.shownFileExtensions = prefs.preferences.general.shownFileExtensions
+        nsViewController.hiddenFileExtensions = prefs.preferences.general.hiddenFileExtensions
         nsViewController.updateSelection()
         return
     }

--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineViewController.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineViewController.swift
@@ -35,6 +35,9 @@ final class OutlineViewController: NSViewController {
     var workspace: WorkspaceDocument?
 
     var iconColor: AppPreferences.FileIconStyle = .color
+    var fileExtensionsVisibility: AppPreferences.FileExtensionsVisibility = .showAll
+    var shownFileExtensions: AppPreferences.FileExtensions = .default
+    var hiddenFileExtensions: AppPreferences.FileExtensions = .default
 
     var rowHeight: Double = 22 {
         didSet {
@@ -164,10 +167,23 @@ extension OutlineViewController: NSOutlineViewDelegate {
             view.icon.image = image
             view.icon.contentTintColor = color(for: item)
 
-            view.label.stringValue = item.fileName
+            view.label.stringValue = outlineViewLabel(for: item)
         }
 
         return view
+    }
+
+    private func outlineViewLabel(for item: Item) -> String {
+        switch fileExtensionsVisibility {
+        case .hideAll:
+            return item.fileName(typeHidden: true)
+        case .showAll:
+            return item.fileName(typeHidden: false)
+        case .showOnly:
+            return item.fileName(typeHidden: !shownFileExtensions.extensions.contains(item.fileType))
+        case .hideOnly:
+            return item.fileName(typeHidden: hiddenFileExtensions.extensions.contains(item.fileType))
+        }
     }
 
     func outlineViewSelectionDidChange(_ notification: Notification) {

--- a/CodeEditModules/Modules/AppPreferences/src/Model/General/GeneralPreferences.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Model/General/GeneralPreferences.swift
@@ -22,7 +22,13 @@ public extension AppPreferences {
         public var showLiveIssues: Bool = true
 
         /// The show file extensions behavior of the app
-        public var fileExtensions: FileExtensions = .showAll
+        public var fileExtensionsVisibility: FileExtensionsVisibility = .showAll
+
+        /// The file extensions collection to display
+        public var shownFileExtensions: FileExtensions = .default
+
+        /// The file extensions collection to hide
+        public var hiddenFileExtensions: FileExtensions = .default
 
         /// The style for file icons
         public var fileIconStyle: FileIconStyle = .color
@@ -60,10 +66,18 @@ public extension AppPreferences {
                 Bool.self,
                 forKey: .showLiveIssues
             ) ?? true
-            self.fileExtensions = try container.decodeIfPresent(
-                FileExtensions.self,
-                forKey: .fileExtensions
+            self.fileExtensionsVisibility = try container.decodeIfPresent(
+                FileExtensionsVisibility.self,
+                forKey: .fileExtensionsVisibility
             ) ?? .showAll
+            self.shownFileExtensions = try container.decodeIfPresent(
+                FileExtensions.self,
+                forKey: .shownFileExtensions
+            ) ?? .default
+            self.hiddenFileExtensions = try container.decodeIfPresent(
+                FileExtensions.self,
+                forKey: .hiddenFileExtensions
+            ) ?? .default
             self.fileIconStyle = try container.decodeIfPresent(
                 FileIconStyle.self,
                 forKey: .fileIconStyle
@@ -124,14 +138,39 @@ public extension AppPreferences {
         case minimized
     }
 
-    /// The style for file extensions display
+    /// The style for file extensions visibility
     ///  - **hideAll**: File extensions are hidden
     ///  - **showAll** File extensions are visible
-    ///  - **showOnly** Display specified file extensions
-    enum FileExtensions: String, Codable {
+    ///  - **showOnly** Specific file extensions are visible
+    ///  - **hideOnly** Specific file extensions are hidden
+    enum FileExtensionsVisibility: Codable, Hashable {
         case hideAll
         case showAll
         case showOnly
+        case hideOnly
+    }
+
+    /// The collection of file extensions used by
+    /// ``FileExtensionsVisibility/showOnly`` or  ``FileExtensionsVisibility/hideOnly`` preference
+    struct FileExtensions: Codable, Hashable {
+        public var extensions: [String]
+
+        public var string: String {
+            get {
+                extensions.joined(separator: ", ")
+            }
+            set {
+                extensions = newValue
+                    .components(separatedBy: ",")
+                    .map({$0.trimmingCharacters(in: .whitespacesAndNewlines)})
+                    .filter({!$0.isEmpty || string.count < newValue.count })
+            }
+        }
+
+        public static var `default` = FileExtensions(extensions: [
+            "c", "cc", "cpp", "h", "hpp", "m", "mm", "gif",
+            "icns", "jpeg", "jpg", "png", "tiff", "swift"
+        ])
     }
     /// The style for file icons
     /// - **color**: File icons appear in their default colors

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/GeneralPreferences/GeneralPreferencesView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/GeneralPreferences/GeneralPreferencesView.swift
@@ -6,11 +6,14 @@
 //
 
 import SwiftUI
+import CodeEditUI
 
 /// A view that implements the `General` preference section
 public struct GeneralPreferencesView: View {
 
     private let inputWidth: Double = 160
+    private let textEditorWidth: Double = 220
+    private let textEditorHeight: Double = 30
 
     @StateObject
     private var prefs: AppPreferencesModel = .shared
@@ -85,21 +88,31 @@ private extension GeneralPreferencesView {
         .disabled(true)
     }
 
-    // TODO: Implement reflecting File Extensions preference and remove disabled modifier
     var fileExtensionsSection: some View {
         PreferencesSection("File Extensions") {
-            Picker("File Extensions:", selection: $prefs.preferences.general.fileExtensions) {
+            Picker("File Extensions:", selection: $prefs.preferences.general.fileExtensionsVisibility) {
                 Text("Hide all")
-                    .tag(AppPreferences.FileExtensions.hideAll)
+                    .tag(AppPreferences.FileExtensionsVisibility.hideAll)
                 Text("Show all")
-                    .tag(AppPreferences.FileExtensions.showAll)
+                    .tag(AppPreferences.FileExtensionsVisibility.showAll)
                 Divider()
                 Text("Show only")
-                    .tag(AppPreferences.FileExtensions.showOnly)
+                    .tag(AppPreferences.FileExtensionsVisibility.showOnly)
+                Text("Hide only")
+                    .tag(AppPreferences.FileExtensionsVisibility.hideOnly)
             }
             .frame(width: inputWidth)
+            if case .showOnly = prefs.preferences.general.fileExtensionsVisibility {
+                SettingsTextEditor(text: $prefs.preferences.general.shownFileExtensions.string)
+                    .frame(width: textEditorWidth)
+                    .frame(height: textEditorHeight)
+            }
+            if case .hideOnly = prefs.preferences.general.fileExtensionsVisibility {
+                SettingsTextEditor(text: $prefs.preferences.general.hiddenFileExtensions.string)
+                .frame(width: textEditorWidth)
+                .frame(height: textEditorHeight)
+            }
         }
-        .disabled(true)
     }
 
     var fileIconStyleSection: some View {

--- a/CodeEditModules/Modules/CodeEditUI/src/SettingsTextEditor.swift
+++ b/CodeEditModules/Modules/CodeEditUI/src/SettingsTextEditor.swift
@@ -1,0 +1,82 @@
+//
+//  SettingsTextEditor.swift
+//  
+//
+//  Created by Andrey Plotnikov on 07.05.2022.
+//
+
+import Foundation
+import SwiftUI
+
+public struct SettingsTextEditor: View {
+    @Binding
+    var text: String
+
+    @State
+    private var isFocus: Bool = false
+
+    public init(text: Binding<String>) {
+        self._text = text
+    }
+
+    public var body: some View {
+        Representable(text: $text, isFocused: $isFocus)
+            .overlay(focusOverlay)
+    }
+
+    private var focusOverlay: some View {
+      Rectangle().stroke(Color.accentColor.opacity(isFocus ? 0.4 : 0), lineWidth: 2)
+    }
+}
+
+private extension SettingsTextEditor {
+    struct Representable: NSViewRepresentable {
+
+        @Binding var text: String
+        @Binding var isFocused: Bool
+
+        func makeNSView(context: Context) -> NSScrollView {
+            let scrollView = NSTextView.scrollableTextView()
+            scrollView.verticalScroller?.alphaValue = 0
+            let textView = scrollView.documentView as? NSTextView
+            textView?.backgroundColor = .windowBackgroundColor
+            textView?.isEditable = true
+            textView?.delegate = context.coordinator
+            textView?.string = text
+            return scrollView
+        }
+
+        func updateNSView(_ nsView: NSScrollView, context: Context) {
+
+        }
+
+        func makeCoordinator() -> Coordinator {
+            Coordinator(parent: self)
+        }
+
+        class Coordinator: NSObject, NSTextViewDelegate {
+            var parent: Representable
+
+            init(parent: Representable) {
+                self.parent = parent
+            }
+
+            func textDidBeginEditing(_ notification: Notification) {
+                parent.isFocused = true
+            }
+
+            func textDidEndEditing(_ notification: Notification) {
+                parent.isFocused = false
+            }
+
+            func textDidChange(_ notification: Notification) {
+                guard let textView = notification.object as? NSTextView else {
+                    return
+                }
+                // Update text
+                self.parent.text = textView.string
+            }
+        }
+    }
+
+}

--- a/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
@@ -110,6 +110,11 @@ public extension WorkspaceClient {
             url.pathExtension
         }
 
+        /// Returns the file name with optional extension (e.g.: `Package.swift`)
+        public func fileName(typeHidden: Bool) -> String {
+            typeHidden ? url.deletingPathExtension().lastPathComponent : fileName
+        }
+
         /// Return the file's UTType
         public var contentType: UTType? {
             try? url.resourceValues(forKeys: [.contentTypeKey]).contentType


### PR DESCRIPTION
…sions (#598)

* Added new preference to store fileExtensions + OutlineView + Settings

* Added documentation description to new types

* Change FileExtensionsCollection to use raw string and compute array of strings

* Add explicit getter and setter to stringValue

* Added NSViewRepresentable and SettingsTextEditor

* fix spacings

* Renamed types and properties to be more clear

* Update SettingsTextEditor.swift

Co-authored-by: Austin Condiff <austin.condiff@gmail.com>

# Description

<!--- REQUIRED: Describe what changed in detail -->

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* #ISSUE_NUMBER

# Checklist

<!--- Add things that are not yet implemented above -->
- [ ] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [ ] My changes generate no new warnings
- [ ] My code builds and runs on my machine
- [ ] I documented my code
- [ ] Review requested

# Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
